### PR TITLE
doc comment added for pluginApp()

### DIFF
--- a/functions_stub.php
+++ b/functions_stub.php
@@ -1,5 +1,11 @@
 <?php
 
+	/**
+	 * @template T
+	 * @param class-string<T> $abstract
+	 * @param array $parameters
+	 * @return T
+	 */
 	 function pluginApp(
 		string $abstract, 
 		array $parameters = []


### PR DESCRIPTION
With generic types we can tell IDEs the correct class return type without defining a /** @var */ comment