### PR TITLE
Update type of Plenty\Modules\Frontend\Contracts\Checkout::getShippingCountryId()

### DIFF
--- a/Modules/Frontend/Contracts/Checkout.php
+++ b/Modules/Frontend/Contracts/Checkout.php
@@ -13,7 +13,7 @@ interface Checkout
 	 * Gets the shipping country ID.
 	 */
 	public function getShippingCountryId(
-	):int;
+	):?int;
 
 	/**
 	 * Updates the ID of the shipping country. The ID must be specified.


### PR DESCRIPTION
The method has proven to return null in some cases (https://forum.plentymarkets.com/t/amazon-pay-fehler-im-log-error/764252)