### PR TITLE
auto-wire return type for pluginApp

### DIFF
--- a/functions_stub.php
+++ b/functions_stub.php
@@ -1,17 +1,26 @@
 <?php
+/**
+ * @template PluginAppClassName of object
+ * @param class-string<PluginAppClassName> $abstract
+ * @return PluginAppClassName
+ */
+function pluginApp(
+    string $abstract,
+    array  $parameters = []
+)
+{
+    return null;
+}
 
-	 function pluginApp(
-		string $abstract, 
-		array $parameters = []
-	)
-	{ return null; }
+function publicPath(
+    string $pluginName = null
+)
+{
+    return null;
+}
 
-	 function publicPath(
-		string $pluginName = null
-	)
-	{ return null; }
-
-	 function pluginSetId(
-	):int
-	{ return null; }
+function pluginSetId(): int
+{
+    return null;
+}
 


### PR DESCRIPTION
This change allows modern IDEs to automatically detect the return type of pluginApp. Thus it makes thousands of PHPDocs var type comments obsolete.

Before:
![image](https://github.com/user-attachments/assets/0470e128-4f2d-4dd1-b770-7b70da89a774)

After:
![image](https://github.com/user-attachments/assets/c0cd89ca-2213-4e52-9502-397b712e8602)
